### PR TITLE
Changed the title from Indian based Languages to Sanskrit based Languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Natural Language Toolkit for Sanskrit Languages (iNLTK)
+## Natural Language Toolkit for Sanskrit based Languages (iNLTK)
 
 ![Alt Text](inltk/static/inltk.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Natural Language Toolkit for Indian Languages (iNLTK)
+## Natural Language Toolkit for Sanskrit Languages (iNLTK)
 
 ![Alt Text](inltk/static/inltk.gif)
 


### PR DESCRIPTION
Languages here are derived from Sanskrit and Sanskrit influenced languages. Language such as Nepali language has been spoken by Nepalese people from ancient times and was not at any point part of India and the language itself is directly derived from Sanskrit, hence it is politically incorrect to classify them under Indian languages.