### PR TITLE
fix requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "requests",
         "scipy",
         "spacy>=2.0.18",
-        "typing",
+        "scikit-learn",
         'fastai==1.0.57',
         "sentencepiece"
     ],


### PR DESCRIPTION
Hi,
The requirements mentioned in the ``setup.py`` file include ``typing`` which is redundant as it is included in the stdlib from python 3.5 onwards see [here](https://pypi.org/project/typing/#:~:text=NOTE%3A%20in%20Python%203.5%20and,newer%20Python%20(bugfix)%20version.). Since iNLTK supports only Python >=3.6 installing typing causes an error. Also sklearn which is needed has been included.
Let me know if I am wrong. Thanks!